### PR TITLE
remove parameter duplication from CStruct macro

### DIFF
--- a/src/test/scala/lms/koika/interpcc_struct.scala
+++ b/src/test/scala/lms/koika/interpcc_struct.scala
@@ -31,17 +31,7 @@ class InterpCcStructTest extends TutorialFunSuite {
     , timer: Int
     )
 
-  trait InterpCc extends Dsl with StructOps {
-    @CStructOps
-    abstract class stateTOps[stateT]
-      ( regs: Array[Int]
-      , saved_regs: Array[Int]
-      , mem: Array[Int]
-      , cache_key: Int
-      , cache_val: Int
-      , timer: Int
-      )
-
+  trait InterpCc extends Dsl with stateTOps {
     def state_reg(s: Rep[stateT], i: Rep[Int]): Rep[Int] =
       s.regs(i)
     def set_state_reg(s: Rep[stateT], i: Rep[Int], v: Rep[Int]): Rep[Unit] =

--- a/vendor/lms-clean/src/test/scala/lms/collection/test_struct.scala
+++ b/vendor/lms-clean/src/test/scala/lms/collection/test_struct.scala
@@ -14,13 +14,10 @@ class StructTest extends TutorialFunSuite {
   @CStruct case class Complex(real: Double, image: Double)
 
   test("basic_struct_is_OK") {
-    val driver = new DslDriverC[Complex, Complex] with StructOps { q =>
+    val driver = new DslDriverC[Complex, Complex] with ComplexOps { q =>
       override val codegen = new DslGenC with CCodeGenStruct {
         val IR: q.type = q
       }
-
-      @CStructOps
-      abstract class ComplexOps[Complex](real: Double, image: Double)
 
       @virtualize
       def snippet(arg: Rep[Complex]) = {


### PR DESCRIPTION
Previously, the `CStructOps` macro had no way of learning the parameter list of the original `CStruct` case class it was associated with. Various reflection-based approaches failed, due to macro expansion happening before such information was populated.

Instead, we create a new trait `<Foo>Ops` inheriting from `StructOps`, in which we define the necessary implicit class. This is necessary so the implicit accessors have the `Rep` type in scope. Now, end clients inherit `<Foo>Ops` (instead of `StructOps`), but everything otherwise appears to work as before.